### PR TITLE
fix: ignore scroll offset for touch triggers

### DIFF
--- a/src/ContextMenuTrigger.js
+++ b/src/ContextMenuTrigger.js
@@ -137,8 +137,8 @@ export default class ContextMenuTrigger extends Component {
         event.preventDefault();
         event.stopPropagation();
 
-        let x = event.clientX || (event.touches && event.touches[0].pageX);
-        let y = event.clientY || (event.touches && event.touches[0].pageY);
+        let x = event.clientX || (event.touches && event.touches[0].clientX);
+        let y = event.clientY || (event.touches && event.touches[0].clientY);
 
         if (this.props.posX) {
             x -= this.props.posX;


### PR DESCRIPTION
If the context menu is triggered by a touch event, it is displayed in the wrong position because the X and Y coordinates include the scroll offset.

The fix is to use `clientX`/`clientY` instead of `pageX`/`pageY`, the same as for mouse events.